### PR TITLE
ES REST client with Authentication & more

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,10 @@ import scalariform.formatter.preferences._
 import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
+
 name := "universal-recommender"
 
-name := "template-scala-parallel-universal-recommendation"
+scalaVersion := "2.11.8"
 
 version := "0.5.0"
 
@@ -15,19 +16,18 @@ val mahoutVersion = "0.13.0"
 
 //val pioVersion = "0.10.0-incubating"
 val pioVersion = "0.11.0-SNAPSHOT"
-
 val elasticsearchVersion = "5.2.1"
 
 libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core" % pioVersion % "provided",
   "org.apache.predictionio" %% "apache-predictionio-data-elasticsearch" % pioVersion % "provided",
-  "org.apache.spark" %% "spark-core" % "1.4.0" % "provided",
-  "org.apache.spark" %% "spark-mllib" % "1.4.0" % "provided",
+  "org.apache.spark" %% "spark-core" % "2.1.0" % "provided",
+  "org.apache.spark" %% "spark-mllib" % "2.1.0" % "provided",
   "org.xerial.snappy" % "snappy-java" % "1.1.1.7",
   // Mahout's Spark libs
   "org.apache.mahout" %% "mahout-math-scala" % mahoutVersion,
   "org.apache.mahout" %% "mahout-spark" % mahoutVersion
-    exclude("org.apache.spark", "spark-core_2.10"),
+    exclude("org.apache.spark", "spark-core_2.11"),
   "org.apache.mahout"  % "mahout-math" % mahoutVersion,
   "org.apache.mahout"  % "mahout-hdfs" % mahoutVersion
     exclude("com.thoughtworks.xstream", "xstream")
@@ -35,9 +35,6 @@ libraryDependencies ++= Seq(
   // other external libs
   "com.thoughtworks.xstream" % "xstream" % "1.4.4"
     exclude("xmlpull", "xmlpull"),
-  "org.elasticsearch" % "elasticsearch-spark-20_2.10" % elasticsearchVersion
-    exclude("org.apache.spark", "spark-catalyst_2.10")
-    exclude("org.apache.spark", "spark-sql_2.10"),
   "org.json4s" %% "json4s-native" % "3.2.10")
   .map(_.exclude("org.apache.lucene","lucene-core")).map(_.exclude("org.apache.lucene","lucene-analyzers-common"))
 
@@ -52,6 +49,9 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(MultilineScaladocCommentsStartOnFirstLine, true)
 
 assemblyMergeStrategy in assembly := {
+  case PathList("javax", "inject", xs @ _*) => MergeStrategy.last
+  case PathList("org", "aopalliance", xs @ _*) => MergeStrategy.last
+  case PathList("org", "apache", "commons", xs @ _*) => MergeStrategy.last
   case "plugin.properties" => MergeStrategy.discard
   case PathList(ps @ _*) if ps.last endsWith "package-info.class" =>
     MergeStrategy.first

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ val mahoutVersion = "0.13.0"
 
 //val pioVersion = "0.10.0-incubating"
 val pioVersion = "0.11.0-SNAPSHOT"
-val elasticsearchVersion = "5.2.1"
+val elasticsearchVersion = "5.1.1"
 
 libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core" % pioVersion % "provided",

--- a/engine.json
+++ b/engine.json
@@ -6,7 +6,7 @@
   "datasource": {
     "params" : {
       "name": "sample-handmade-data.txt",
-      "appName": "handmade",
+      "appName": "ur",
       "eventNames": ["purchase", "view"]
     }
   },
@@ -22,7 +22,7 @@
       "comment": "simplest setup where all values are default, popularity based backfill, must add eventsNames",
       "name": "ur",
       "params": {
-        "appName": "handmade",
+        "appName": "ur",
         "indexName": "urindex",
         "typeName": "items",
         "comment": "must have data for the first event or the model will not build, other events are optional",

--- a/src/main/scala/EsClient.scala
+++ b/src/main/scala/EsClient.scala
@@ -196,10 +196,14 @@ object EsClient {
   /** Commits any pending changes to the index */
   def refreshIndex(indexName: String): Unit = {
     val restClient = client.open()
-    restClient.performRequest(
-      "POST",
-      s"/$indexName/_refresh",
-      Map.empty[String, String].asJava)
+    try {
+      restClient.performRequest(
+        "POST",
+        s"/$indexName/_refresh",
+        Map.empty[String, String].asJava)
+    } finally {
+      restClient.close()
+    }
   }
 
   /** Create new index and hot-swap the new after it's indexed and ready to take over, then delete the old */

--- a/template.json
+++ b/template.json
@@ -1,1 +1,1 @@
-{"pio": {"version": { "min": "0.9.7-aml" }}}
+{"pio": {"version": { "min": "0.11.0-SNAPSHOT" }}}


### PR DESCRIPTION
I'm currently testing using your fork of the Universal Recommender with this [PredictionIO 0.11.0 branch that enables basic HTTP authentication](https://github.com/apache/incubator-predictionio/pull/372) for Elasticsearch.

Just opening this pull request to share with you what we're doing, not trying to merge yet, and see if you're headed in the same direction. @dszeto pointed me to your fork.

Things we've done:

* [x] upgrade to Scala 2.11 & Spark 2.1
* [x] use a custom PredictionIO 0.11.0 SNAPSHOT for Authentication (this is in a local Maven repo)
* [x] fixup JSON request bodies for index creation

To do:

* [ ] fix EsClient#hotSwap to work from an initial, empty state

Curious to know if any of this seems useful to you? Have you hit any issues with initial ES index creation?

Thanks for sharing your progress so far 😃